### PR TITLE
Improve assertion methods call for consistency

### DIFF
--- a/test/Container/ConfigProviderTest.php
+++ b/test/Container/ConfigProviderTest.php
@@ -38,6 +38,6 @@ final class ConfigProviderTest extends TestCase
     {
         $actual = (new ConfigProvider())->__invoke();
 
-        self::assertSame(self::EXPECTED_CONFIG, $actual);
+        $this->assertSame(self::EXPECTED_CONFIG, $actual);
     }
 }

--- a/test/Handler/RemoveFeatureFactoryTest.php
+++ b/test/Handler/RemoveFeatureFactoryTest.php
@@ -20,13 +20,13 @@ final class RemoveFeatureFactoryTest extends TestCase
         $factory = new RemoveFeatureFactory();
         $actual = $factory->__invoke($mockedContainer);
 
-        self::assertInstanceOf(RemoveFeature::class, $actual);
+        $this->assertInstanceOf(RemoveFeature::class, $actual);
     }
 
     public function testItShouldCreateARemoveFeatureFromCreate(): void
     {
         $actual = RemoveFeatureFactory::create($this->createMock(FeatureRepository::class));
 
-        self::assertInstanceOf(RemoveFeature::class, $actual);
+        $this->assertInstanceOf(RemoveFeature::class, $actual);
     }
 }

--- a/test/Handler/RemoveFeatureTest.php
+++ b/test/Handler/RemoveFeatureTest.php
@@ -30,7 +30,7 @@ final class RemoveFeatureTest extends TestCase
         $repository->expects($this->once())
             ->method('remove')
             ->with($this->callback(function (Feature $feature) use ($expectedFeature) {
-                $this->assertEquals($expectedFeature, $feature);
+                $this->assertSame($expectedFeature, $feature);
 
                 return true;
             }));

--- a/test/Handler/RemoveStrategyFactoryTest.php
+++ b/test/Handler/RemoveStrategyFactoryTest.php
@@ -19,13 +19,13 @@ class RemoveStrategyFactoryTest extends TestCase
         $factory = new RemoveStrategyFactory();
         $actual = $factory->__invoke($mockedContainer);
 
-        self::assertInstanceOf(RemoveStrategy::class, $actual);
+        $this->assertInstanceOf(RemoveStrategy::class, $actual);
     }
 
     public function testItShouldCreateARemoveStrategyFromCreate(): void
     {
         $actual = RemoveStrategyFactory::create($this->createMock(FeatureRepository::class));
 
-        self::assertInstanceOf(RemoveStrategy::class, $actual);
+        $this->assertInstanceOf(RemoveStrategy::class, $actual);
     }
 }


### PR DESCRIPTION
# Changed log

- Be consistency to let all assertion method calls be `$this` approach.
- Using the `assertSame` to make assertion equals strict.